### PR TITLE
Handle Expired Access Token

### DIFF
--- a/src/NetSapiensSharp/Connector.cs
+++ b/src/NetSapiensSharp/Connector.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using RestSharp;
 using RestSharp.Serializers.NewtonsoftJson;
 


### PR DESCRIPTION
Add logic to check if our current access token has expired based on the expires_in seconds allotted. If the token is expired, clear the session token to generate a new access token.