### PR TITLE
AB#10560 Add site field to user object

### DIFF
--- a/src/NetSapiensSharp/Objects/User.cs
+++ b/src/NetSapiensSharp/Objects/User.cs
@@ -17,6 +17,7 @@ namespace NetSapiensSharp.Objects
             public string pwd { get; set; }
             public string pwd_hash { get; set; }
             public string group { get; set; }
+            public string site { get; set; }
             public string dir { get; set; }
             public string email { get; set; }
             public string presence { get; set; }


### PR DESCRIPTION
Per NetSapiens API documentation, the "Site" field exists on the user/subscriber response model as shown below:
https://api.netsapiens.com/ns-api/webroot/apidoc/#api-Subscriber-Read

![image](https://github.com/Rev-io/NetSapiensSharp/assets/93213727/4a08bdcf-287a-42f2-8c54-4b8e42da9549)


Tested this locally and the data is coming over
![image](https://github.com/Rev-io/NetSapiensSharp/assets/93213727/2c0550ce-07eb-4ef1-9786-aa4c619b1cc4)